### PR TITLE
Vencrypt fixes v2

### DIFF
--- a/rfbproto.rst
+++ b/rfbproto.rst
@@ -686,6 +686,16 @@ No. of bytes    Type    Description
 If client supports none of the VeNCrypt subtypes it terminates
 connection.
 
+For TLS and X509 subtypes, the server then sends a one byte response
+which indicates if everything is OK. Non-one value means failure and
+connection will be closed. One value means success.
+
+=============== ======= ===============================================
+No. of bytes    Type    Description
+=============== ======= ===============================================
+1               ``U8``  Ack
+=============== ======= ===============================================
+
 When subtype is selected authentication continues as written in particular
 VeNCrypt subtype description.
 

--- a/rfbproto.rst
+++ b/rfbproto.rst
@@ -674,8 +674,8 @@ Code            Name            Description
 264             X509SASL        X509 encryption with SASL authentication
 =============== =============== =======================================
 
-After that client selects one VeNCrypt subtype sends back number of that
-type.
+After that client selects one VeNCrypt subtype and sends back the
+number of that type.
 
 =============== ======= ===============================================
 No. of bytes    Type    Description

--- a/rfbproto.rst
+++ b/rfbproto.rst
@@ -674,6 +674,9 @@ Code            Name            Description
 264             X509SASL        X509 encryption with SASL authentication
 =============== =============== =======================================
 
+In addition, any of the normal VNC security types (except VeNCrypt) may
+be sent.
+
 After that client selects one VeNCrypt subtype and sends back the
 number of that type.
 


### PR DESCRIPTION
New pull request as #4  is closed. Same as #4 except:
 - Clarify that ack message is only sent for TLS/X509 subtypes
 - Clarify that non-vencrypt subtypes may be enumerated in the vencrypt handshake as well
