### PR TITLE
Clarify the existing uses of Compression Level Pseudo-encoding

### DIFF
--- a/rfbproto.rst
+++ b/rfbproto.rst
@@ -3217,6 +3217,10 @@ levels should be used for any given bandwidth. The compression level is
 just a hint for the server, and there is no specification for what a
 specific compression level means.
 
+There are VNC server implementations that also use compression level
+as a hint to prefer or deprefer lossless compression mechanisms over
+JPEG-based ones.
+
 QEMU Pointer Motion Change Pseudo-encoding
 ------------------------------------------
 


### PR DESCRIPTION
When compression level is high, old Vino (e.g. 3.8.1) takes it as a
hint to prefer JPEG when using the Tight encoding, while modern
libvncserver thinks it should avoid JPEG and prefer palette.