### PR TITLE
Document Tight PNG encoding.

### DIFF
--- a/rfbproto.rst
+++ b/rfbproto.rst
@@ -2315,6 +2315,14 @@ Number       Name
 7            `Tight Encoding`_
 8            `zlibhex Encoding`_
 16           `ZRLE Encoding`_
+-260         `Tight PNG Encoding`_
+============ ==========================================================
+
+The pseudo-encodings defined in this document are:
+
+============ ==========================================================
+Number       Name
+============ ==========================================================
 -23 to -32   `JPEG Quality Level Pseudo-encoding`_
 -223         `DesktopSize Pseudo-encoding`_
 -224         `LastRect Pseudo-encoding`_
@@ -2359,7 +2367,6 @@ Number                      Name
 -225                        PointerPos
 -226 to -238                Tight options
 -241 to -246                Tight options
--260                        Tight PNG
 -262 to -272                QEMU
 -273 to -304                VMWare
 -306                        popa
@@ -3051,6 +3058,45 @@ are:
     =================== =============== ======= =======================
 
     Where *r* is floor((*runLength* - 1) / 255).
+
+Tight PNG Encoding
+-------------------------
+
+The Tight PNG encoding is a variant of the Tight encoding that
+disallows the **BasicCompression** type and replaces it with a new
+**PngCompression** type. The purpose of this encoding is to support
+clients which have efficient PNG decoding/rendering (perhaps even in
+hardware) but may have inefficient decoding of the raw zlib data
+contained in the **BasicCompression** type.
+
+The Tight PNG encoding is identical to the Tight encoding except that
+bit 7-4 of the *compression-control* byte indicate either
+**FillCompression**, **JpegCompression**, or **PngCompression** and
+are interpreted as follows:
+
+=============== =================== ===================================
+Bits            Binary value        Description
+=============== =================== ===================================
+7-4             1000                **FillCompression**
+..              1001                **JpegCompression**
+..              1010                **PngCompression**
+..              any other           Invalid
+=============== =================== ===================================
+
+**FillCompression**
+    Identical to Tight encoding.
+
+**JpegCompression**
+    Identical to Tight encoding. As with the Tight encoding,
+    **JpegCompression** may only be used when *bits-per-pixel* is
+    either 16 or 32 and the client has advertized a quality level
+    using the `JPEG Quality Level Pseudo-encoding`_
+
+**PngCompression**
+    If the compression type is **PngCompression**, the data stream is
+    the same as **JpegCompression** (as defined in the Tight encoding)
+    except that the *jpeg-data* is replaced by *png-data* which is
+    image data in the PNG (Portable Network Graphics) format.
 
 Pseudo-encodings
 ++++++++++++++++


### PR DESCRIPTION
Relevant issue: https://github.com/rfbproto/rfbproto/issues/9

The Tight PNG encoding was designed as part of a Google Summer of Code
project by Corentin Chary, Alexander Graf, Anthony Liguori, and Joel
Martin in June 2010.

The encoding was initially implemented in noVNC, QEMU and libvncserver
by the following commits:
    - https://github.com/novnc/noVNC/commit/29cb15f9caf3130260dc5d3e64235f77e21d89dc (Jun 9, 2010)
    - https://github.com/qemu/qemu/commit/efe556adb75a20ab71f3e5b1c5b19bf045e7953f (Jul 7, 2010)
    - https://github.com/LibVNC/libvncserver/commit/896ca2036c35b89a7f63e1adefe5e3724bf4d40d (Jul 19, 2011)

Relevant links:
    https://wiki.qemu.org/Features/VNC_Tight_PNG
    https://wiki.qemu.org/Google_Summer_of_Code_2010/VNC#Tight_PNG
    https://sourceforge.net/p/libvncserver/mailman/message/29200412/

Signed-off-by: Joel Martin <github@martintribe.org>