### PR TITLE
Document Unicode keysyms

### DIFF
--- a/rfbproto.rst
+++ b/rfbproto.rst
@@ -1643,6 +1643,12 @@ used:
   viewers, servers should also recognise ISO Left Tab as meaning a
   shifted Tab.
 
+- Unicode characters can be represented using Unicode keysyms, which
+  occupy the range `0x01000100`` to `0x0110FFFF`` and represent the ISO
+  10646 / Unicode characters `U+0100` to `U+10FFFF`, respectively. The
+  numeric value of a Unicode keysym is the Unicode position of the
+  corresponding character plus `0x01000000`.
+
 Note that extensions such as `QEMU Extended Key Event Message`_ provide
 alternative behaviours for keyboard events that do not follow what is
 described here.


### PR DESCRIPTION
Keysym values in the 0xFF00 - 0xFFFF range conflict with Unicode characters in the same range.

This commit adds a note indicating the presence of [Unicode keysyms](https://www.x.org/releases/X11R7.7/doc/xproto/x11protocol.html#Unicode_KEYSYM). They are:
- Part of [recent versions of the X Window System Protocol](https://www.x.org/releases/X11R7.7/doc/xproto/x11protocol.html#Unicode_KEYSYM)
- Documented in [RFC 6143](https://datatracker.ietf.org/doc/html/rfc6143#section-7.5.4)
- Appear to be supported by at least [TurboVNC](https://github.com/TurboVNC/turbovnc/blob/33550c8453235c99c9fadc659eb56739c7857bb9/unix/vncviewer/keysym2ucs.c#L866) and [novnc](https://github.com/novnc/noVNC/blob/829725b30e3d3486991e34db0c86406e556ebf98/core/input/keysymdef.js#L686)