### PR TITLE
Clarify Open H.264 handling of oversized frames

### DIFF
--- a/rfbproto.rst
+++ b/rfbproto.rst
@@ -3526,6 +3526,11 @@ into multiple packets. The *data* field must always contain 0 or more
 whole frames. The client must first decode all the received frames
 in a single message, and then display the result.
 
+The server may send frames that are larger than the associated rectangle
+in either dimension, but frames should never be smaller. The client
+must crop oversized frames to fit the rectangle by trimming off the
+bottom and/or right side.
+
 The server must start sending *data* for the new context from I-frame
 to provide correct decoding for the client side.
 


### PR DESCRIPTION
This clarifies how clients should treat frames that are either larger or smaller than the rectangle to which they belong.

Hardware encoders are often limited in that frame sizes need to be multiples of certain numbers such as 16 or 32. It is therefor advantageous to allow servers to submit oversized frames, expecting the client to crop them.

See: https://github.com/TigerVNC/tigervnc/pull/1785