### PR TITLE
Document Tight Encoding Without Zlib extension

### DIFF
--- a/rfbproto.rst
+++ b/rfbproto.rst
@@ -2720,6 +2720,7 @@ Number       Name
 -312         `Fence Pseudo-encoding`_
 -313         `ContinuousUpdates Pseudo-encoding`_
 -314         `Cursor With Alpha Pseudo-encoding`_
+-317         `Tight Encoding Without Zlib Pseudo-encoding`_
 -412 to -512 `JPEG Fine-Grained Quality Level Pseudo-encoding`_
 -763 to -768 `JPEG Subsampling Level Pseudo-encoding`_
 0x574d5664   `VMware Cursor Pseudo-encoding`_
@@ -3098,20 +3099,27 @@ Bits            Binary value        Description
 =============== =================== ===================================
 
 Otherwise, if the bit 7 of *compression-control* is set to 1, then the
-compression method is either **FillCompression** or
-**JpegCompression**, depending on other bits of the same byte:
+compression method is either **FillCompression**, **JpegCompression**,
+or **BasicCompression Without Zlib**, depending on other bits of the
+same byte:
 
 =============== =================== ===================================
 Bits            Binary value        Description
 =============== =================== ===================================
 7-4             1000                **FillCompression**
 ..              1001                **JpegCompression**
+..              1010                **BasicCompression Without Zlib**
+..              1110                **BasicCompression Without Zlib**,
+                                    *read-filter-id*
 ..              any other           Invalid
 =============== =================== ===================================
 
 Note: **JpegCompression** may only be used when *bits-per-pixel* is
 either 16 or 32 and the client has advertized a quality level using the
 `JPEG Quality Level Pseudo-encoding`_.
+
+Note: **BasicCompression Without Zlib** may only be used if the client
+has advertised the `Tight Encoding Without Zlib Pseudo-encoding`_.
 
 The Tight encoding makes use of a new type ``TPIXEL`` (Tight pixel).
 This is the same as a ``PIXEL`` for the agreed pixel format, except
@@ -3247,6 +3255,12 @@ compression method.
     *compression-control* byte are set to 1. Note that the decoder must
     reset the indicated zlib streams even if the compression type is
     **FillCompression** or **JpegCompression**.
+
+**BasicCompression Without Zlib**
+    **BasicCompression Without Zlib** is identical to
+    **BasicCompression** except that all data is sent as is,
+    uncompressed.  This is useful with server-area networks or loopback
+    connections in which minimizing CPU overhead is desirable.
 
 zlibhex Encoding
 ----------------
@@ -4092,6 +4106,14 @@ supported. However some encodings may be unsuitable as they cannot
 include the extra bits that are used for alpha. Also note that the data
 used for the cursor shares state with other rects. E.g. the zlib stream
 for a ZRLE encoding is the same as for data rects.
+
+Tight Encoding Without Zlib Pseudo-encoding
+-------------------------------------------
+
+A client which requests the *Tight Encoding Without Zlib*
+pseudo-encoding is declaring that it is capable of decoding a Tight
+subrectangle encoded with the **BasicCompression Without Zlib**
+compression method.  (Refer to `Tight Encoding`_.)
 
 JPEG Fine-Grained Quality Level Pseudo-encoding
 -----------------------------------------------


### PR DESCRIPTION
This extension has been used unofficially in TurboVNC since 2008, in order to support a Tight-based encoding method that compresses almost as well as Hextile (4-6x relative to Raw) while using about half as much CPU time as Hextile.  The original purpose of the extension was to support older SPARC CPUs that couldn't keep up with JPEG or zlib decompression on a gigabit network.  However, it has found a new purpose on loopback connections to virtual machines, as well as in enterprise environments that run a VNC viewer inside of Citrix or Remote Desktop and want to minimize re-encoding overhead while still reducing server-area network usage.

Even with zlib-ng (which has SIMD acceleration and numerous other optimizations), bypassing zlib altogether results in about a 10% speedup in average Tight encoding performance relative to zlib level 0 (assuming that JPEG subencoding is disabled.)  With the unaccelerated zlib implementation, the speedup is about 60% for zlib 1.2.7 and 15% for zlib 1.2.11.