### PR TITLE
Define semantics for colour map after VMWare Display Mode Change psuedo-encoding

### DIFF
--- a/rfbproto.rst
+++ b/rfbproto.rst
@@ -4734,23 +4734,8 @@ Clients supporting multi-head layouts must wait for this following
 *ExtendedDesktopSize* rectangle to determine the new layout.
 
 The *width*  and *height* of the pseudo-rectangle specify the new width
-and height of the display. The rest of the format is described below:
-
-=============== ==================== =======================
-No. of bytes    Type                 Description
-=============== ==================== =======================
-1               ``U8``               *bits-per-sample*
-1               ``U8``               *depth*
-1               ``U8``               *color*
-1               ``U8``               *true-color*
-2               ``U16``              *max-red*
-2               ``U16``              *max-green*
-2               ``U16``              *max-blue*
-1               ``U8``               *red-shift*
-1               ``U8``               *green-shift*
-1               ``U8``               *blue-shift*
-3                                    padding
-=============== ==================== =======================
+and height of the display, followed by ``PIXEL_FORMAT`` as described in
+`ServerInit`_.
 
 VMware Virtual Machine State Pseudo-encoding
 --------------------------------------------

--- a/rfbproto.rst
+++ b/rfbproto.rst
@@ -4722,6 +4722,12 @@ ServerInitialisation header to facilitate client implementations.
 
 The new pixel format takes effect immediately after the server sends
 a pseudo-rectangle with the VMware Display Mode Change pseudo-encoding.
+If *true-colour-flag* is zero (false) then this indicates that a
+"colour map" is to be used. The server can set any of the entries in
+the colour map using the *SetColourMapEntries* message
+(`SetColourMapEntries`_). Immediately after the client has sent this
+message the colour map is empty, even if entries had previously been
+set by the server.
 
 When the `ExtendedDesktopSize Pseudo-encoding`_ encoding is also
 supported by both the server and client, the server must send an


### PR DESCRIPTION
This originates with a bug I received against GTK-VNC, where we fail to preserve the colour map entries when handling any messages which trigger re-creation of the local framebuffer - either a desktop resize, or a pixel format change.

In fixing this I sought to understand when we should & should not preserve colour map entries. I observed the spec says we should NOT preserve colour map entries on SetPixelFormat, but failed to say anything about "VMVare Display Mode Change" & I think the semantics of the latter should match the former.

~Note, QEMU is not in compliance with these new documented semantics, as while it sends "SetColorMapEntries" after receiving a "SetPixelFormat" message, it fails to do the same after sending the "VMware Display Mode Change" psuedo-encoding.~

~Fixing QEMU to follow the new spec, should be backwards compatible with existing clients:~

* ~If a client DID NOT previously reset its view of the colour map. It would carry on with old (outdated) colourmap. Seeing a new SetColorMapEntries message is something the client should already be ready to handle. With QEMU fixed, a client using stale colour map info would now have correct colour map info. Functionally better.~
 
* ~If a client DID previously reset its view of the colour map. It would be lacking the ability to render framebuffer updates due to lack of SetColorMapEntries message from QEMU. With QEMU fixed, a previously broken client would start working.~